### PR TITLE
Unify plugin and npm ids to fix problems with Cordova 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,7 @@ Initial release.
 ## Version 0.1.3
 
   * Change namespace to `mayflower` for consistency.
+
+## Version 0.1.4
+
+  * Unify plugin and NPM ids to `cordova-android-plugin` to fix problems with Cordova 7.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,4 @@ Initial release.
 
 ## Version 0.1.4
 
-  * Unify plugin and NPM ids to `cordova-android-plugin` to fix problems with Cordova 7.
+  * Unify plugin and NPM ids to `cordova-android-movetasktoback` to fix problems with Cordova 7.

--- a/js/plugin.js
+++ b/js/plugin.js
@@ -2,7 +2,7 @@
 
 var exec = require('cordova/exec'),
     argscheck = require('cordova/argscheck'),
-    tsd = require('cordova-plugin-android-movetasktoback.tsd'),
+    tsd = require('cordova-android-movetasktoback.tsd'),
     cordova = require('cordova');
 
 var SERVICE_NAME = 'MoveTaskToBack';

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "cordova-android-movetasktoback",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "\n        Exposes Activity::moveTaskToBack to cordova. Allows to return to the previous activity programatically.\n    ",
   "cordova": {
-    "id": "cordova-plugin-android-movetasktoback",
+    "id": "cordova-android-movetasktoback",
     "platforms": [
       "android"
     ]

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="cordova-plugin-android-movetasktoback" version="0.1.3">
+        id="cordova-android-movetasktoback" version="0.1.4">
 
     <name>cordova-android-movetasktoback</name>
 


### PR DESCRIPTION
Hi @DirtyHairy!

Having different ids in `package.json` (cordova-android-movetasktoback) and `plugin.xml` (cordova-plugin-android-movetasktoback) is giving Cordova 7 a hard time, as it now uses npm fetch by default and writes plugins and dependencies to `package.json`, leading to the following error:

```
npm ERR! code E404
npm ERR! 404 Not Found: cordova-plugin-android-movetasktoback@^0.1.3
```

This PR unifies both as `cordova-android-movetasktoback` (its npm name) and bumps the version to 0.1.4.

Thanks!